### PR TITLE
\Phalcon\Loader

### DIFF
--- a/src/Phalcon/Loader.php
+++ b/src/Phalcon/Loader.php
@@ -412,6 +412,12 @@ class Loader implements EventsAwareInterface
 				continue;
 			}
 
+			//Replace seperator
+			if($ch === ord($seperator)) {
+				$virtualStr .= $virtualSeperator;
+				continue;
+			}
+
 			//Basic alphanumeric characters
 			if($ch === 95 || // _
 				($ch >= 48 && $ch <= 57) || // >="0" && <= "9"


### PR DESCRIPTION
Phalcon's original LoaderTest no longer finds any errors and only one failure:

```
21) LoaderTest::testEvents
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
 Array (
+    'beforeCheckClass' => Array (...)
+    'beforeCheckPath' => Array (...)
+    'pathFound' => Array (...)
 )

/phalcon-php/test/cphalcon/LoaderTest.php:232
```

I haven't properly looked at the Events component yet so it's possible the problem is in there.
